### PR TITLE
chore: update Dockerfile to reduce the image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY . /app
 USER root
 
 RUN apt-get update
-RUN apt-get install libssl-dev pkg-config -y
+RUN apt-get install --no-install-recommends libssl-dev pkg-config -y && rm -rf /var/lib/apt/lists/*;
 RUN cargo build --release
 
 # Copy the binary into a new container for a smaller docker image
@@ -15,7 +15,7 @@ FROM debian:buster-slim
 WORKDIR /etc/lust
 
 RUN apt-get update \
-    && apt-get install -y ca-certificates libssl-dev pkg-config \
+    && apt-get install --no-install-recommends -y ca-certificates libssl-dev pkg-config \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /app/target/release/lust ./


### PR DESCRIPTION
Hi there,

I've made a small improvement to the Dockerfile that I think could help optimize the image size.

Summary of the changes:
* I added the `--no-install-recommends` to with apt-get in order to not install unnecessary packages and reduce the image size.
* I put `apt-get update` and `apt-get install` in a single layer to optimize the layers and reduce the number of unneeded files
* I added `rm -rf /var/lib/apt/lists/*` after `apt-get install` which removes unnecessary files and reduces the size of the image.


Impact on the image size:
* Image size before repair: 186.45 MB
* Image size after repair: 148.73 MB
* Difference: 37.72 MB (20.23%)

I hope that you will find these changes useful to you. Let me know if you have any questions or concerns.

Thanks,